### PR TITLE
CVE-2013-0887 and CVE-2014-3201

### DIFF
--- a/cves/CVE-2013-0887.yml
+++ b/cves/CVE-2013-0887.yml
@@ -36,6 +36,10 @@ description: |
   The developer-tools process in Google Chrome before 25.0.1364.97 on Windows and Linux,
   and before 25.0.1364.99 on Mac OS X, does not properly restrict privileges during
   interaction with a connected server, which has unspecified impact and attack vectors.
+
+  This allowed the developer-tools process to access the web ui bindings, which
+  it did not neeed access to. This opened up numerous attack vectors, although
+  was easily resolved by simply removing the bindings to the web ui
 bounty_instructions: |
   If you came across any indications that a bounty was paid out for this
   vulnerability, fill it out here. Or correct it if the information already here

--- a/cves/CVE-2013-0887.yml
+++ b/cves/CVE-2013-0887.yml
@@ -67,7 +67,7 @@ upvotes_instructions: |
   upvotes to each vulnerability you see. Your peers will tell you how
   interesting they think this vulnerability is, and you'll add that to the
   upvotes score on your branch.
-upvotes: 
+upvotes: 3
 unit_tested:
   question: |
     Were automated unit tests involved in this vulnerability?

--- a/cves/CVE-2013-0887.yml
+++ b/cves/CVE-2013-0887.yml
@@ -81,8 +81,8 @@ unit_tested:
     For the "fix" answer below, check if the fix for the vulnerability involves
     adding or improving an automated test to ensure this doesn't happen again.
   answer: No
-  code: 
-  fix: 
+  code: false
+  fix: false
 discovered:
   question: |
     How was this vulnerability discovered?

--- a/cves/CVE-2013-0887.yml
+++ b/cves/CVE-2013-0887.yml
@@ -162,8 +162,10 @@ lessons:
     applies: 
     note: 
   least_privilege:
-    applies: 
-    note: 
+    applies: true
+    note: |
+      This bug came about because the devtools process was able to access and use more than it needed to to do it's
+      job.
   frameworks_are_optional:
     applies: 
     note: 

--- a/cves/CVE-2013-0887.yml
+++ b/cves/CVE-2013-0887.yml
@@ -187,7 +187,9 @@ lessons:
     note: 
   yagni:
     applies: true
-    note: The bug came about as a result of a binding being present that wasn't needed
+    note: |
+      The bug was caused by the devtools process allowing access to the web UI bindings, which wasn't necessary.
+      Presumably, this binding policy was included at one point with the expectation that it would be required.
   complex_inputs:
     applies: 
     note: 
@@ -204,5 +206,7 @@ mistakes:
     every one. Write a thoughtful entry here that those ing the software
     engineering industry would find interesting.
   answer: |
-    This mistake likely came about due to adding functionality that wasn't needed yet, be it for future planning or
-    functionality. Ultimately, the fix was simple, and involved just removing the binding.
+    This bug was caused by the devtools process allowing access to the web UI bindings,
+    which was not necessary. It is likely it came about from planning ahead during devtools development,
+    with the assumption that the web UI bindings would be needed.
+    It is clear that the binding was in fact not needed, as the fix was quick and involved simply removing the binding.

--- a/cves/CVE-2013-0887.yml
+++ b/cves/CVE-2013-0887.yml
@@ -4,14 +4,14 @@ CWE_instructions: |
   Please go to cwe.mitre.org and find the most specific, appropriate CWE entry
   that describes your vulnerability. (Tip: this may not be a good one to start
   with - spend time understanding this vulnerability before making your choice!)
-CWE: 
+CWE: CWE-264
 curated_instructions: |
   If you are manually editing this file, then you are "curating" it. Set the
   entry below to "true" as soon as you start. This will enable additional
   integrity checks on this file to make sure you fill everything out properly.
   If you are a student, we cannot accept your work as finished unless curated is
   set to true.
-curated: false
+curated: true
 announced_instructions: |
   Was there a date that this vulnerability was announced to the world? You can
   find this in changelogs, blogs, bug reports, or perhaps the CVE date. A good
@@ -32,7 +32,10 @@ description_instructions: |
   that outsiders to Chromium would not understand. Technology like "regular
   expressions" is fine, and security phrases like "invalid write" are fine to
   keep too.
-description: 
+description: |
+  The developer-tools process in Google Chrome before 25.0.1364.97 on Windows and Linux,
+  and before 25.0.1364.99 on Mac OS X, does not properly restrict privileges during
+  interaction with a connected server, which has unspecified impact and attack vectors.
 bounty_instructions: |
   If you came across any indications that a bounty was paid out for this
   vulnerability, fill it out here. Or correct it if the information already here
@@ -53,9 +56,9 @@ fixes_vcc_instructions: |
   CVE-2011-3092.yml). Fixes and VCCs follow the same format.
 fixes:
 - :commit: 253a50f8235c702c704d2fb169ba7289e32ab924
-  :note: ''
+  :note: Removed web ui bindings from dev tools process
 vccs:
-- :commit:
+- :commit: 2b8cf90084f83ee5901caeeb84bd5bc9e620f31f
   :note: 
 upvotes_instructions: |
   For the first round, ignore this upvotes number.
@@ -77,7 +80,7 @@ unit_tested:
 
     For the "fix" answer below, check if the fix for the vulnerability involves
     adding or improving an automated test to ensure this doesn't happen again.
-  answer: 
+  answer: No
   code: 
   fix: 
 discovered:
@@ -95,7 +98,7 @@ discovered:
 
     If there is no evidence as to how this vulnerability was found, then you may
     leave the entries blank except for "answer". Write down where you looked in "answer".
-  answer: 
+  answer: A bug submitted to the tracker. No other information is available, since the issue is hidden
   date: 
   automated: 
   google: 
@@ -107,8 +110,8 @@ subsystem:
     Look at the path of the source code files code that were fixed to get
     directory names. Look at comments in the code. Look at the bug reports how
     the bug report was tagged. Examples: "clipboard", "gpu", "ssl", "speech", "renderer"
-  answer: 
-  name: 
+  answer: The DevTools subsystem binding to the web ui
+  name: devtools
 interesting_commits:
   question: |
     Are there any interesting commits between your VCC(s) and fix(es)?
@@ -118,7 +121,9 @@ interesting_commits:
     emerging themes?
 
     If there are no interesting commits, demonstrate that you completed this section by explaining what happened between the VCCs and the fix.
-  answer:
+  answer: |
+    There were no interesting commits between the VCC and the fix. However, there were numerous refactors that modified
+    the line, for example changing it from BindingsPolicy::WEB_UI to content::BINDINGS_POLICY_WEB_UI
   commits:
   - commit: 
     note: 
@@ -132,7 +137,7 @@ major_events:
 
     The event doesn't need to be directly related to this vulnerability, rather,
     we want to capture what the development team was dealing with at the time.
-  answer: 
+  answer: BindingsPolicy was renamed and constants moved to the content namespace
   events:
   - name: 
     date: 
@@ -181,8 +186,8 @@ lessons:
     applies: 
     note: 
   yagni:
-    applies: 
-    note: 
+    applies: true
+    note: The bug came about as a result of a binding being present that wasn't needed
   complex_inputs:
     applies: 
     note: 
@@ -198,4 +203,6 @@ mistakes:
     Use those questions to inspire your answer. Don't feel obligated to answer
     every one. Write a thoughtful entry here that those ing the software
     engineering industry would find interesting.
-  answer: 
+  answer: |
+    This mistake likely came about due to adding functionality that wasn't needed yet, be it for future planning or
+    functionality. Ultimately, the fix was simple, and involved just removing the binding.

--- a/cves/CVE-2014-3201.yml
+++ b/cves/CVE-2014-3201.yml
@@ -4,14 +4,14 @@ CWE_instructions: |
   Please go to cwe.mitre.org and find the most specific, appropriate CWE entry
   that describes your vulnerability. (Tip: this may not be a good one to start
   with - spend time understanding this vulnerability before making your choice!)
-CWE: 
+CWE: CWE-119
 curated_instructions: |
   If you are manually editing this file, then you are "curating" it. Set the
   entry below to "true" as soon as you start. This will enable additional
   integrity checks on this file to make sure you fill everything out properly.
   If you are a student, we cannot accept your work as finished unless curated is
   set to true.
-curated: false
+curated: true
 announced_instructions: |
   Was there a date that this vulnerability was announced to the world? You can
   find this in changelogs, blogs, bug reports, or perhaps the CVE date. A good
@@ -32,7 +32,11 @@ description_instructions: |
   that outsiders to Chromium would not understand. Technology like "regular
   expressions" is fine, and security phrases like "invalid write" are fine to
   keep too.
-description: 
+description: |
+  core/rendering/compositing/RenderLayerCompositor.cpp in Blink,
+  as used in Google Chrome before 38.0.2125.102 on Android,
+  does not properly handle a certain IFRAME overflow condition,
+  which allows remote attackers to spoof content via a crafted web site that interferes with the scrollbar.
 bounty_instructions: |
   If you came across any indications that a bounty was paid out for this
   vulnerability, fill it out here. Or correct it if the information already here
@@ -47,16 +51,20 @@ reviews:
 - 579073002
 bugs:
 - 406593
-repo: 
+repo: http://src.chromium.org/viewvc/blink/trunk
 fixes_vcc_instructions: |
   Please put the commit hash in "commit" below (see my example in
   CVE-2011-3092.yml). Fixes and VCCs follow the same format.
 fixes:
 - :commit: e80ebbdab2ce3d2e343fb6d9e2fe9ce149986377
-  :note: ''
+  :note: |
+    The fix was simple, and included clipping the iframe overflow controls via m_overflowControlsHostLayer
 vccs:
-- :commit:
-  :note: 
+- :commit: 19a0bb3d5af98720d0159b148a1f625c9596e5f8
+  :note: |
+    This vcc set the root clip layer not to maskToBounds.
+    This was an interesting vcc, because it mentioned the only reason it might be
+    needed would be to avoid overlapping the scrollbars.
 upvotes_instructions: |
   For the first round, ignore this upvotes number.
 
@@ -77,9 +85,10 @@ unit_tested:
 
     For the "fix" answer below, check if the fix for the vulnerability involves
     adding or improving an automated test to ensure this doesn't happen again.
-  answer: 
-  code: 
-  fix: 
+  answer: |
+    A test expectation was added based on the new functionality
+  code: true
+  fix: true
 discovered:
   question: |
     How was this vulnerability discovered?
@@ -95,10 +104,11 @@ discovered:
 
     If there is no evidence as to how this vulnerability was found, then you may
     leave the entries blank except for "answer". Write down where you looked in "answer".
-  answer: 
-  date: 
-  automated: 
-  google: 
+  answer: |
+    The reporter found the bug, and provided a high quality proof of concept
+  date: 2014-08-22
+  automated: false
+  google: false
   contest: 
 subsystem:
   question: |
@@ -107,8 +117,8 @@ subsystem:
     Look at the path of the source code files code that were fixed to get
     directory names. Look at comments in the code. Look at the bug reports how
     the bug report was tagged. Examples: "clipboard", "gpu", "ssl", "speech", "renderer"
-  answer: 
-  name: 
+  answer: The vulnerability was in the class RenderLayerCompositor
+  name: renderer
 interesting_commits:
   question: |
     Are there any interesting commits between your VCC(s) and fix(es)?
@@ -118,9 +128,11 @@ interesting_commits:
     emerging themes?
 
     If there are no interesting commits, demonstrate that you completed this section by explaining what happened between the VCCs and the fix.
-  answer:
+  answer: |
+    There were not many interesting commits between the VSS and the fix, aside from one,
+      that affected how the root graphics layer was scaled for mobile devides
   commits:
-  - commit: 
+  - commit: 6bac145510b27faae57809327bdaf93b2fd0e5cc
     note: 
   - commit: 
     note: 
@@ -132,10 +144,12 @@ major_events:
 
     The event doesn't need to be directly related to this vulnerability, rather,
     we want to capture what the development team was dealing with at the time.
-  answer: 
+  answer: |
+    The only major event between these times were the change of the name of the module,
+    which likely did not affect or cause this vulnerability
   events:
-  - name: 
-    date: 
+  - name: Rename WebCore namespace to Blink
+    date: 2014-06-18
   - name: 
     date: 
 lessons:
@@ -154,8 +168,10 @@ lessons:
     If you think of another lesson we covered in class that applies here, feel
     free to give it a small name and add one in the same format as these.
   defense_in_depth:
-    applies: 
-    note: 
+    applies: true
+    note: |
+      In the case of this vulnerability, it could have been mitigated by not trusting the loaded iframe as much or
+      allowing it to modify the scrollbar
   least_privilege:
     applies: 
     note: 
@@ -198,4 +214,8 @@ mistakes:
     Use those questions to inspire your answer. Don't feel obligated to answer
     every one. Write a thoughtful entry here that those ing the software
     engineering industry would find interesting.
-  answer: 
+  answer: |
+    This vulnerability came about not because of any direct mistakes per say,
+    rather the fact that the iframe was able to modify the scrollbar, and use
+    that to spoof content. While this was fixed by bounding the frames overflow,
+    it likely could have been fixed somewhere else

--- a/cves/CVE-2014-3201.yml
+++ b/cves/CVE-2014-3201.yml
@@ -37,6 +37,9 @@ description: |
   as used in Google Chrome before 38.0.2125.102 on Android,
   does not properly handle a certain IFRAME overflow condition,
   which allows remote attackers to spoof content via a crafted web site that interferes with the scrollbar.
+
+  This CVE allowed applications in an iframe to modify the scrollbar via css,
+  allowing the iframe to spoof content on the website outside of it's actual frame.
 bounty_instructions: |
   If you came across any indications that a bounty was paid out for this
   vulnerability, fill it out here. Or correct it if the information already here

--- a/cves/CVE-2014-3201.yml
+++ b/cves/CVE-2014-3201.yml
@@ -170,8 +170,9 @@ lessons:
   defense_in_depth:
     applies: true
     note: |
-      In the case of this vulnerability, it could have been mitigated by not trusting the loaded iframe as much or
-      allowing it to modify the scrollbar
+      In the case of this vulnerability, it was fixed by clipping the iframe overflow controls.
+      However, there are multiple levels this issue can be fixed on, including restricting permissions for
+      iframes, such as not allowing them to modify the scrollbar.
   least_privilege:
     applies: 
     note: 

--- a/cves/CVE-2014-3201.yml
+++ b/cves/CVE-2014-3201.yml
@@ -65,7 +65,7 @@ fixes:
 vccs:
 - :commit: 19a0bb3d5af98720d0159b148a1f625c9596e5f8
   :note: |
-    This vcc set the root clip layer not to maskToBounds.
+    This vcc set the root contianer layer not to maskToBounds, instead of the clip layer.
     This was an interesting vcc, because it mentioned the only reason it might be
     needed would be to avoid overlapping the scrollbars.
 upvotes_instructions: |
@@ -137,7 +137,7 @@ interesting_commits:
   commits:
   - commit: 6bac145510b27faae57809327bdaf93b2fd0e5cc
     note: 
-  - commit: 
+  - commit:
     note: 
 major_events:
   question: |

--- a/cves/CVE-2014-3201.yml
+++ b/cves/CVE-2014-3201.yml
@@ -222,4 +222,4 @@ mistakes:
     This vulnerability came about not because of any direct mistakes per say,
     rather the fact that the iframe was able to modify the scrollbar, and use
     that to spoof content. While this was fixed by bounding the frames overflow,
-    it likely could have been fixed somewhere else
+    it likely could have been fixed somewhere else.

--- a/cves/CVE-2014-3201.yml
+++ b/cves/CVE-2014-3201.yml
@@ -136,7 +136,7 @@ interesting_commits:
       that affected how the root graphics layer was scaled for mobile devides
   commits:
   - commit: 6bac145510b27faae57809327bdaf93b2fd0e5cc
-    note: 
+    note: This commit affected how the root graphics layer was scaled for mobile devices
   - commit:
     note: 
 major_events:

--- a/cves/CVE-2014-3201.yml
+++ b/cves/CVE-2014-3201.yml
@@ -75,7 +75,7 @@ upvotes_instructions: |
   upvotes to each vulnerability you see. Your peers will tell you how
   interesting they think this vulnerability is, and you'll add that to the
   upvotes score on your branch.
-upvotes: 
+upvotes: 4
 unit_tested:
   question: |
     Were automated unit tests involved in this vulnerability?


### PR DESCRIPTION
## CVE-2013-0887
The developer-tools process in Google Chrome before 25.0.1364.97 on Windows and Linux, and before 25.0.1364.99 on Mac OS X, does not properly restrict privileges during interaction with a connected server, which has unspecified impact and attack vectors.

## CVE-2014-3201
core/rendering/compositing/RenderLayerCompositor.cpp in Blink, as used in Google Chrome before 38.0.2125.102 on Android, does not properly handle a certain IFRAME overflow condition, which allows remote attackers to spoof content via a crafted web site that interferes with the scrollbar.