### PR TITLE
CVE-2011-2850 and CVE-2013-6628

### DIFF
--- a/cves/CVE-2011-2850.yml
+++ b/cves/CVE-2011-2850.yml
@@ -216,6 +216,6 @@ mistakes:
   answer: |
      This seems like an issue that could have been caught earlier with improved testing. Harfbuzz itself 
      contains tests against a list of languages, Khmer originally not being one of them. Additionally, while 
-     it was eventually caught by their fuzzed, it existed for almost a year before a person or the fuzzer 
+     it was eventually caught by their fuzzer, it existed for almost a year before a person or the fuzzer 
      caught this. With properly bounding unit tests they could have discovered the ease for OOB errors much 
      earlier, especially when they can be caused by just a single character in Khmer or Tibetan.

--- a/cves/CVE-2011-2850.yml
+++ b/cves/CVE-2011-2850.yml
@@ -33,7 +33,13 @@ description_instructions: |
   expressions" is fine, and security phrases like "invalid write" are fine to
   keep too.
 description: |
-  khmer characters were causing an out of bound error when being read. Even a file made up of just one khmer was able to cause an out of bound error.
+  khmer characters were causing an out of bound error when being read. Even a file made up of just one khmer 
+  was able to cause an out of bound error. Khmer is not a technical for certain characters, Khmer is the official language of cambodia.
+  
+  An attack taking advantage of this vulnerability would have remote attackers utilizing unspecified vectors 
+  to upload Khmer characters that would cause an out of bound error leading to denial of service.
+  
+  The issue itself cropped up in the library they were using from harfbuzz. Harfbuzz is used to convert unicode text to glyphs.
 bounty_instructions: |
   If you came across any indications that a bounty was paid out for this
   vulnerability, fill it out here. Or correct it if the information already here
@@ -64,7 +70,7 @@ upvotes_instructions: |
   upvotes to each vulnerability you see. Your peers will tell you how
   interesting they think this vulnerability is, and you'll add that to the
   upvotes score on your branch.
-upvotes: 
+upvotes: 3
 unit_tested:
   question: |
     Were automated unit tests involved in this vulnerability?
@@ -110,7 +116,7 @@ subsystem:
     directory names. Look at comments in the code. Look at the bug reports how
     the bug report was tagged. Examples: "clipboard", "gpu", "ssl", "speech", "renderer"
   answer: based on the components in the issue
-  name: Blink
+  name: harfbuzz
 interesting_commits:
   question: |
     Are there any interesting commits between your VCC(s) and fix(es)?
@@ -190,7 +196,10 @@ lessons:
   complex_inputs:
     applies: true
     note: |
-      this entire vulnerability had to do with the handling of khmer characters which is the official language of cambodia, and made of very unique symbols.
+      this entire vulnerability had to do with the handling of khmer characters which is the official 
+      language of cambodia, and made of very unique symbols. This was able to be reproduced by exactly one 
+      character which, when rendered using harfbuzz, was rendered by two or more glyphs. '&#6068' was an 
+      example character that would break harfbuzz.
 mistakes:
   question: |
     In your opinion, after all of this research, what mistakes were made that
@@ -204,4 +213,8 @@ mistakes:
     every one. Write a thoughtful entry here that those ing the software
     engineering industry would find interesting.
   answer: |
-     This seems like an issue that could have been caught earlier with proper testing. Additionally, while it was eventually caught by their fuzzed, it existed for almost a year before a person or the fuzzer caught this. With properly bounding unit tests they could have discovered the ease for OOB errors much earlier, especially when they can be caused by just a single character in khmer or tibetan.
+     This seems like an issue that could have been caught earlier with improved testing. Harfbuzz itself 
+     contains tests against a list of languages, Khmer originally not being one of themAdditionally, while 
+     it was eventually caught by their fuzzed, it existed for almost a year before a person or the fuzzer 
+     caught this. With properly bounding unit tests they could have discovered the ease for OOB errors much 
+     earlier, especially when they can be caused by just a single character in khmer or tibetan.

--- a/cves/CVE-2011-2850.yml
+++ b/cves/CVE-2011-2850.yml
@@ -33,13 +33,14 @@ description_instructions: |
   expressions" is fine, and security phrases like "invalid write" are fine to
   keep too.
 description: |
-  khmer characters were causing an out of bound error when being read. Even a file made up of just one khmer 
-  was able to cause an out of bound error. Khmer is not a technical for certain characters, Khmer is the official language of cambodia.
+  Khmer characters were causing an out of bound error when being read. This out of bound 
+  error was even being caused by a file made up of just one Khmer character. Khmer is not 
+  a technical for certain characters, Khmer is actually the official language of Cambodia.
   
   An attack taking advantage of this vulnerability would have remote attackers utilizing unspecified vectors 
   to upload Khmer characters that would cause an out of bound error leading to denial of service.
   
-  The issue itself cropped up in the library they were using from harfbuzz. Harfbuzz is used to convert unicode text to glyphs.
+  The issue itself cropped up in the library they were using from Harfbuzz. Harfbuzz is used to convert unicode text to glyphs.
 bounty_instructions: |
   If you came across any indications that a bounty was paid out for this
   vulnerability, fill it out here. Or correct it if the information already here
@@ -59,10 +60,10 @@ fixes_vcc_instructions: |
   CVE-2011-3092.yml). Fixes and VCCs follow the same format.
 fixes:
 - :commit: 7763a6a02fcd4479111530b64b9f6e00899aad2d
-  :note: They added a conditional to see if characters are being correctly covered to a patch for harfbuzz
+  :note: Google added a conditional to see if the characters are correctly being converted in a patch for Harfbuzz.
 vccs:
 - :commit: fd367aa0ef3e542ad63e6bb46d0c997b46e27a74
-  :note: the fix occurs in a patch file so the best vcc I can find is that same patch file 
+  :note: The fix occurs in a patch file so the best vcc I can find is that same patch file .
 upvotes_instructions: |
   For the first round, ignore this upvotes number.
 
@@ -70,7 +71,7 @@ upvotes_instructions: |
   upvotes to each vulnerability you see. Your peers will tell you how
   interesting they think this vulnerability is, and you'll add that to the
   upvotes score on your branch.
-upvotes: 3
+upvotes: 9
 unit_tested:
   question: |
     Were automated unit tests involved in this vulnerability?
@@ -84,7 +85,7 @@ unit_tested:
     For the "fix" answer below, check if the fix for the vulnerability involves
     adding or improving an automated test to ensure this doesn't happen again.
   answer: |
-    The code was not obviously tested but had a new test case added to cover the added functionality for the fix
+    The code was not obviously tested, but it had a new test case added to cover the added functionality for the fix.
   code: false
   fix: true
 discovered:
@@ -103,7 +104,7 @@ discovered:
     If there is no evidence as to how this vulnerability was found, then you may
     leave the entries blank except for "answer". Write down where you looked in "answer".
   answer: |
-    The bug was found first by a google employee in harfbuzz, and they also had a fuzzer which 'caught up' and found the error as well.
+    The bug was found first by a google employee in Harfbuzz, and they also had a fuzzer which 'caught up' and found the error as well.
   date: 07-22-2011
   automated: true
   google: true
@@ -115,8 +116,8 @@ subsystem:
     Look at the path of the source code files code that were fixed to get
     directory names. Look at comments in the code. Look at the bug reports how
     the bug report was tagged. Examples: "clipboard", "gpu", "ssl", "speech", "renderer"
-  answer: based on the components in the issue
-  name: harfbuzz
+  answer: The subsystem I found is based on the components in the issue.
+  name: Harfbuzz
 interesting_commits:
   question: |
     Are there any interesting commits between your VCC(s) and fix(es)?
@@ -127,10 +128,10 @@ interesting_commits:
 
     If there are no interesting commits, demonstrate that you completed this section by explaining what happened between the VCCs and the fix.
   answer: |
-     it seems a similar thing also happened when reading tibetan syllables a couple months later
+     It seems that a similar thing happened again when reading Tibetan syllables a couple months later.
   commits:
   - commit: b103b5975f6ac1b1b491510b8246091f160d9013
-    note: this is where they first notice the OOB caused by tibetan syllables
+    note: This is where they first notice the OOB caused by tibetan syllables.
   - commit: 
     note: 
 major_events:
@@ -142,7 +143,7 @@ major_events:
     The event doesn't need to be directly related to this vulnerability, rather,
     we want to capture what the development team was dealing with at the time.
   answer: |
-    there were no major events that seemed to be going on at the time, nothing too big or that seemed too complicated
+    There were no major events that seemed to be going on at the time, nothing too big or that seemed too complicated.
   events:
   - name: 
     date: 
@@ -196,11 +197,11 @@ lessons:
   complex_inputs:
     applies: true
     note: |
-      this entire vulnerability had to do with the handling of khmer characters which is the official 
-      language of cambodia, and made of very unique symbols. This was able to be reproduced by exactly one 
-      character which, when rendered using harfbuzz, was rendered by two or more glyphs. '&#6068' was an 
-      example character that would break harfbuzz.
-mistakes:
+      This entire vulnerability had to do with the handling of Khmer characters, which is the official 
+      language of Cambodia. Khmer characters are made of very unique symbols. This was able to be reproduced by exactly one 
+      character which, when rendered using Harfbuzz, was rendered by two or more glyphs. '&#6068' was an 
+      example character that would break Harfbuzz.
+mistakes:   
   question: |
     In your opinion, after all of this research, what mistakes were made that
     led to this vulnerability? Coding mistakes? Design mistakes?
@@ -214,7 +215,7 @@ mistakes:
     engineering industry would find interesting.
   answer: |
      This seems like an issue that could have been caught earlier with improved testing. Harfbuzz itself 
-     contains tests against a list of languages, Khmer originally not being one of themAdditionally, while 
+     contains tests against a list of languages, Khmer originally not being one of them. Additionally, while 
      it was eventually caught by their fuzzed, it existed for almost a year before a person or the fuzzer 
      caught this. With properly bounding unit tests they could have discovered the ease for OOB errors much 
-     earlier, especially when they can be caused by just a single character in khmer or tibetan.
+     earlier, especially when they can be caused by just a single character in Khmer or Tibetan.

--- a/cves/CVE-2011-2850.yml
+++ b/cves/CVE-2011-2850.yml
@@ -4,14 +4,14 @@ CWE_instructions: |
   Please go to cwe.mitre.org and find the most specific, appropriate CWE entry
   that describes your vulnerability. (Tip: this may not be a good one to start
   with - spend time understanding this vulnerability before making your choice!)
-CWE: 
+CWE: 125
 curated_instructions: |
   If you are manually editing this file, then you are "curating" it. Set the
   entry below to "true" as soon as you start. This will enable additional
   integrity checks on this file to make sure you fill everything out properly.
   If you are a student, we cannot accept your work as finished unless curated is
   set to true.
-curated: false
+curated: true
 announced_instructions: |
   Was there a date that this vulnerability was announced to the world? You can
   find this in changelogs, blogs, bug reports, or perhaps the CVE date. A good
@@ -32,7 +32,8 @@ description_instructions: |
   that outsiders to Chromium would not understand. Technology like "regular
   expressions" is fine, and security phrases like "invalid write" are fine to
   keep too.
-description: 
+description: |
+  khmer characters were causing an out of bound error when being read. Even a file made up of just one khmer was able to cause an out of bound error.
 bounty_instructions: |
   If you came across any indications that a bounty was paid out for this
   vulnerability, fill it out here. Or correct it if the information already here
@@ -52,10 +53,10 @@ fixes_vcc_instructions: |
   CVE-2011-3092.yml). Fixes and VCCs follow the same format.
 fixes:
 - :commit: 7763a6a02fcd4479111530b64b9f6e00899aad2d
-  :note: ''
+  :note: They added a conditional to see if characters are being correctly covered to a patch for harfbuzz
 vccs:
-- :commit:
-  :note: 
+- :commit: fd367aa0ef3e542ad63e6bb46d0c997b46e27a74
+  :note: the fix occurs in a patch file so the best vcc I can find is that same patch file 
 upvotes_instructions: |
   For the first round, ignore this upvotes number.
 
@@ -76,9 +77,10 @@ unit_tested:
 
     For the "fix" answer below, check if the fix for the vulnerability involves
     adding or improving an automated test to ensure this doesn't happen again.
-  answer: 
-  code: 
-  fix: 
+  answer: |
+    The code was not obviously tested but had a new test case added to cover the added functionality for the fix
+  code: false
+  fix: true
 discovered:
   question: |
     How was this vulnerability discovered?
@@ -94,11 +96,12 @@ discovered:
 
     If there is no evidence as to how this vulnerability was found, then you may
     leave the entries blank except for "answer". Write down where you looked in "answer".
-  answer: 
-  date: 
-  automated: 
-  google: 
-  contest: 
+  answer: |
+    The bug was found first by a google employee in harfbuzz, and they also had a fuzzer which 'caught up' and found the error as well.
+  date: 07-22-2011
+  automated: true
+  google: true
+  contest: false
 subsystem:
   question: |
     What subsystems was the mistake in?
@@ -106,8 +109,8 @@ subsystem:
     Look at the path of the source code files code that were fixed to get
     directory names. Look at comments in the code. Look at the bug reports how
     the bug report was tagged. Examples: "clipboard", "gpu", "ssl", "speech", "renderer"
-  answer: 
-  name: 
+  answer: based on the components in the issue
+  name: Blink
 interesting_commits:
   question: |
     Are there any interesting commits between your VCC(s) and fix(es)?
@@ -117,10 +120,11 @@ interesting_commits:
     emerging themes?
 
     If there are no interesting commits, demonstrate that you completed this section by explaining what happened between the VCCs and the fix.
-  answer:
+  answer: |
+     it seems a similar thing also happened when reading tibetan syllables a couple months later
   commits:
-  - commit: 
-    note: 
+  - commit: b103b5975f6ac1b1b491510b8246091f160d9013
+    note: this is where they first notice the OOB caused by tibetan syllables
   - commit: 
     note: 
 major_events:
@@ -131,7 +135,8 @@ major_events:
 
     The event doesn't need to be directly related to this vulnerability, rather,
     we want to capture what the development team was dealing with at the time.
-  answer: 
+  answer: |
+    there were no major events that seemed to be going on at the time, nothing too big or that seemed too complicated
   events:
   - name: 
     date: 
@@ -183,8 +188,9 @@ lessons:
     applies: 
     note: 
   complex_inputs:
-    applies: 
-    note: 
+    applies: true
+    note: |
+      this entire vulnerability had to do with the handling of khmer characters which is the official language of cambodia, and made of very unique symbols.
 mistakes:
   question: |
     In your opinion, after all of this research, what mistakes were made that
@@ -197,4 +203,5 @@ mistakes:
     Use those questions to inspire your answer. Don't feel obligated to answer
     every one. Write a thoughtful entry here that those ing the software
     engineering industry would find interesting.
-  answer: 
+  answer: |
+     This seems like an issue that could have been caught earlier with proper testing. Additionally, while it was eventually caught by their fuzzed, it existed for almost a year before a person or the fuzzer caught this. With properly bounding unit tests they could have discovered the ease for OOB errors much earlier, especially when they can be caused by just a single character in khmer or tibetan.

--- a/cves/CVE-2013-6628.yml
+++ b/cves/CVE-2013-6628.yml
@@ -145,9 +145,7 @@ major_events:
 
     The event doesn't need to be directly related to this vulnerability, rather,
     we want to capture what the development team was dealing with at the time.
-  answer: |
-   There did appear to be some major events at the time, the first event being adding support for 
-   libssl as a component using global variables allowing for correct initialization. The other event being the disabling of ECDSA on platforms that don't support the algorithm.
+  answer: There did appear to be some major events at the time, the first event being adding support for libssl as a component using global variables allowing for correct initialization. The other event being the disabling of ECDSA on platforms that don't support the algorithm.
   events:
   - name: 2e70a8df3c5d63219ecd1ac9bbeac8e02773d4d9
     date: 02-28-2013

--- a/cves/CVE-2013-6628.yml
+++ b/cves/CVE-2013-6628.yml
@@ -4,14 +4,14 @@ CWE_instructions: |
   Please go to cwe.mitre.org and find the most specific, appropriate CWE entry
   that describes your vulnerability. (Tip: this may not be a good one to start
   with - spend time understanding this vulnerability before making your choice!)
-CWE: 
+CWE: 297
 curated_instructions: |
   If you are manually editing this file, then you are "curating" it. Set the
   entry below to "true" as soon as you start. This will enable additional
   integrity checks on this file to make sure you fill everything out properly.
   If you are a student, we cannot accept your work as finished unless curated is
   set to true.
-curated: false
+curated: true
 announced_instructions: |
   Was there a date that this vulnerability was announced to the world? You can
   find this in changelogs, blogs, bug reports, or perhaps the CVE date. A good
@@ -26,13 +26,17 @@ description_instructions: |
   Rewrite this description in your own words. Make it interesting and easy to
   read to anyone with some programming experience. We can always pull up the NVD
   description later to get more technical.
-
+  
   Try to still be specific in your description, but remove Chromium-specific
   stuff. Remove references to versions, specific filenames, and other jargon
   that outsiders to Chromium would not understand. Technology like "regular
   expressions" is fine, and security phrases like "invalid write" are fine to
   keep too.
-description: 
+description: |
+  Google Chrome was not checking that the digital certificate is the same during 
+  renegotiation of the client socket as it was before the renegotiation. This
+  means that remote web servers could interfere with trust relationships of a session.
+  keep too.
 bounty_instructions: |
   If you came across any indications that a bounty was paid out for this
   vulnerability, fill it out here. Or correct it if the information already here
@@ -54,12 +58,12 @@ fixes_vcc_instructions: |
   CVE-2011-3092.yml). Fixes and VCCs follow the same format.
 fixes:
 - :commit: 8dd1631f2aa8512be172e3d94a209d241baeb36d
-  :note: ''
+  :note: Adds catching for if the server certificate changed from the beginning of renegotiation, and makes it unable to happen
 - :commit: b051cdb6465736e7233cd22b807e255554378206
-  :note: ''
+  :note: Does the same thing as the first commit except makes it unable for the certificate to change from OpenSSL
 vccs:
-- :commit:
-  :note: 
+- :commit: 81bbe06f0740a5816d1d91d70c93cf3421ef5dce
+  :note: Added several error cases to nss_ssl_util.cc, including a todo for some extra. No one noticed the need for a renegotiation error case
 upvotes_instructions: |
   For the first round, ignore this upvotes number.
 
@@ -79,10 +83,11 @@ unit_tested:
     for this module.
 
     For the "fix" answer below, check if the fix for the vulnerability involves
-    adding or improving an automated test to ensure this doesn't happen again.
-  answer: 
-  code: 
-  fix: 
+    adding or improving an automated test to ensur--e this doesn't happen again.
+  answer: |
+     looking at the code it seems there were both no unit tests here and none added in the fix
+  code: false
+  fix: false
 discovered:
   question: |
     How was this vulnerability discovered?
@@ -98,7 +103,9 @@ discovered:
 
     If there is no evidence as to how this vulnerability was found, then you may
     leave the entries blank except for "answer". Write down where you looked in "answer".
-  answer: 
+  answer: |
+    'You do not have permission to view the requested page.
+    Reason: User is not allowed to view this issue.' for some reason I am unauthorized to view this bug report.
   date: 
   automated: 
   google: 
@@ -110,8 +117,8 @@ subsystem:
     Look at the path of the source code files code that were fixed to get
     directory names. Look at comments in the code. Look at the bug reports how
     the bug report was tagged. Examples: "clipboard", "gpu", "ssl", "speech", "renderer"
-  answer: 
-  name: 
+  answer: from the directory names
+  name: net/socket
 interesting_commits:
   question: |
     Are there any interesting commits between your VCC(s) and fix(es)?
@@ -121,7 +128,8 @@ interesting_commits:
     emerging themes?
 
     If there are no interesting commits, demonstrate that you completed this section by explaining what happened between the VCCs and the fix.
-  answer:
+  answer: | 
+    no interesting commits pertaining to this vulnerability. There was a lot that happened between the VCCs and the fix... commit implementing AES GCM cipher suites and a 'fix' for the TLS authentication bug, supporting the build of NSS's libssl as a component, reporting of new error cases, but the issue here was that they missed an error case, none of these commits lead to or assisted or influenced this vulnerability.
   commits:
   - commit: 
     note: 
@@ -135,12 +143,12 @@ major_events:
 
     The event doesn't need to be directly related to this vulnerability, rather,
     we want to capture what the development team was dealing with at the time.
-  answer: 
+  answer: There did appear to be some major events at the time
   events:
-  - name: 
-    date: 
-  - name: 
-    date: 
+  - name: 2e70a8df3c5d63219ecd1ac9bbeac8e02773d4d9
+    date: 02-28-2013
+  - name: a6194ed157fda49d8332c03112ce8cdee0eaba9e
+    date: 08-16-2012
 lessons:
   question: |
     Are there any common lessons we have learned from class that apply to this
@@ -201,4 +209,5 @@ mistakes:
     Use those questions to inspire your answer. Don't feel obligated to answer
     every one. Write a thoughtful entry here that those ing the software
     engineering industry would find interesting.
-  answer: 
+  answer: |
+    This was either a design mistake or a coding mistake but I am leaning more towards design mistake. At some point they know that renegotiation of sockets happens, and they know that there is a certificate proving what you were before renegotiation. No one had considered(at a design point) that during renegotiation the certificate could be changed. And up until the point that renegotiation got handled in the code, no one included any cases for if it had or added code saying it could not.

--- a/cves/CVE-2013-6628.yml
+++ b/cves/CVE-2013-6628.yml
@@ -33,10 +33,14 @@ description_instructions: |
   expressions" is fine, and security phrases like "invalid write" are fine to
   keep too.
 description: |
-  Google Chrome was not checking that the digital certificate is the same during 
-  renegotiation of the client socket as it was before the renegotiation. This
-  means that remote web servers could interfere with trust relationships of a session.
-  keep too.
+  Google Chrome was not checking that the servers digital certificate, which exists as 
+  part of the SSL authorization process, is the same during renegotiation of the client socket as it was 
+  before the renegotiation. Renegotiation is a way to adjust the the parameters of the SSL 
+  handshake without needing to make a new SSL sessionThismeans that remote web servers could 
+  interfere with trust relationships of a session.
+  
+  An example attack of this would involve starting a renegotiation during the authentication between 
+  the server and client, changing the certificate sent by the server so that it gets authenticated by the client.
 bounty_instructions: |
   If you came across any indications that a bounty was paid out for this
   vulnerability, fill it out here. Or correct it if the information already here
@@ -118,7 +122,7 @@ subsystem:
     directory names. Look at comments in the code. Look at the bug reports how
     the bug report was tagged. Examples: "clipboard", "gpu", "ssl", "speech", "renderer"
   answer: from the directory names
-  name: net/socket
+  name: ssl
 interesting_commits:
   question: |
     Are there any interesting commits between your VCC(s) and fix(es)?
@@ -129,12 +133,10 @@ interesting_commits:
 
     If there are no interesting commits, demonstrate that you completed this section by explaining what happened between the VCCs and the fix.
   answer: | 
-    no interesting commits pertaining to this vulnerability. There was a lot that happened between the VCCs and the fix... commit implementing AES GCM cipher suites and a 'fix' for the TLS authentication bug, supporting the build of NSS's libssl as a component, reporting of new error cases, but the issue here was that they missed an error case, none of these commits lead to or assisted or influenced this vulnerability.
-  commits:
-  - commit: 
-    note: 
-  - commit: 
-    note: 
+    no interesting commits pertaining to this vulnerability. There was a lot that happened between the VCCs and the fix... 
+    commit implementing AES GCM cipher suites and a 'fix' for the TLS authentication bug, supporting the build of NSS's libssl 
+    as a component, reporting of new error cases, but the issue here was that they missed an error case, none of these commits 
+    lead to or assisted or influenced this vulnerability.
 major_events:
   question: |
     Please record any major events you found in the history of this
@@ -143,7 +145,9 @@ major_events:
 
     The event doesn't need to be directly related to this vulnerability, rather,
     we want to capture what the development team was dealing with at the time.
-  answer: There did appear to be some major events at the time
+  answer: |
+   There did appear to be some major events at the time, the first event being adding support for 
+   libssl as a component using global variables allowing for correct initialization. The other event being the disabling of ECDSA on platforms that don't support the algorithm.
   events:
   - name: 2e70a8df3c5d63219ecd1ac9bbeac8e02773d4d9
     date: 02-28-2013
@@ -210,4 +214,8 @@ mistakes:
     every one. Write a thoughtful entry here that those ing the software
     engineering industry would find interesting.
   answer: |
-    This was either a design mistake or a coding mistake but I am leaning more towards design mistake. At some point they know that renegotiation of sockets happens, and they know that there is a certificate proving what you were before renegotiation. No one had considered(at a design point) that during renegotiation the certificate could be changed. And up until the point that renegotiation got handled in the code, no one included any cases for if it had or added code saying it could not.
+    This was either a design mistake or a coding mistake but I am leaning more towards design mistake. 
+    At some point they know that renegotiation of sockets happens, and they know that there is a certificate proving 
+    what you were before renegotiation. No one had considered(at a design point) that during renegotiation the certificate 
+    could be changed. And up until the point that renegotiation got handled in the code, no one included any cases for if 
+    it had or added code saying it could not.

--- a/cves/CVE-2013-6628.yml
+++ b/cves/CVE-2013-6628.yml
@@ -36,7 +36,7 @@ description: |
   Google Chrome was not checking that the servers digital certificate, which exists as 
   part of the SSL authorization process, is the same during renegotiation of the client socket as it was 
   before the renegotiation. Renegotiation is a way to adjust the the parameters of the SSL 
-  handshake without needing to make a new SSL sessionThismeans that remote web servers could 
+  handshake without needing to make a new SSL session. This means that remote web servers could 
   interfere with trust relationships of a session.
   
   An example attack of this would involve starting a renegotiation during the authentication between 
@@ -62,9 +62,9 @@ fixes_vcc_instructions: |
   CVE-2011-3092.yml). Fixes and VCCs follow the same format.
 fixes:
 - :commit: 8dd1631f2aa8512be172e3d94a209d241baeb36d
-  :note: Adds catching for if the server certificate changed from the beginning of renegotiation, and makes it unable to happen
+  :note: Adds catching for if the server certificate changed from the beginning of renegotiation, and makes it unable to happen.
 - :commit: b051cdb6465736e7233cd22b807e255554378206
-  :note: Does the same thing as the first commit except makes it unable for the certificate to change from OpenSSL
+  :note: Does the same thing as the first commit except makes it unable for the certificate to change from OpenSSL.
 vccs:
 - :commit: 81bbe06f0740a5816d1d91d70c93cf3421ef5dce
   :note: Added several error cases to nss_ssl_util.cc, including a todo for some extra. No one noticed the need for a renegotiation error case
@@ -75,7 +75,7 @@ upvotes_instructions: |
   upvotes to each vulnerability you see. Your peers will tell you how
   interesting they think this vulnerability is, and you'll add that to the
   upvotes score on your branch.
-upvotes: 
+upvotes: 2
 unit_tested:
   question: |
     Were automated unit tests involved in this vulnerability?
@@ -87,9 +87,9 @@ unit_tested:
     for this module.
 
     For the "fix" answer below, check if the fix for the vulnerability involves
-    adding or improving an automated test to ensur--e this doesn't happen again.
+    adding or improving an automated test to ensure this doesn't happen again.
   answer: |
-     looking at the code it seems there were both no unit tests here and none added in the fix
+     Looking at the code, it seems there were both no unit tests here and none added in the fix.
   code: false
   fix: false
 discovered:
@@ -108,8 +108,10 @@ discovered:
     If there is no evidence as to how this vulnerability was found, then you may
     leave the entries blank except for "answer". Write down where you looked in "answer".
   answer: |
+    As of 11/3/2018, bug report with the id of '306959' has viewership with restricted access.
+    The error displayed is:
     'You do not have permission to view the requested page.
-    Reason: User is not allowed to view this issue.' for some reason I am unauthorized to view this bug report.
+    Reason: User is not allowed to view this issue.'
   date: 
   automated: 
   google: 
@@ -121,7 +123,7 @@ subsystem:
     Look at the path of the source code files code that were fixed to get
     directory names. Look at comments in the code. Look at the bug reports how
     the bug report was tagged. Examples: "clipboard", "gpu", "ssl", "speech", "renderer"
-  answer: from the directory names
+  answer: The subsystem I found is based on the directory names.
   name: ssl
 interesting_commits:
   question: |
@@ -133,10 +135,9 @@ interesting_commits:
 
     If there are no interesting commits, demonstrate that you completed this section by explaining what happened between the VCCs and the fix.
   answer: | 
-    no interesting commits pertaining to this vulnerability. There was a lot that happened between the VCCs and the fix... 
-    commit implementing AES GCM cipher suites and a 'fix' for the TLS authentication bug, supporting the build of NSS's libssl 
-    as a component, reporting of new error cases, but the issue here was that they missed an error case, none of these commits 
-    lead to or assisted or influenced this vulnerability.
+    There were no interesting commits pertaining to this vulnerability. There was, however, a lot that happened between the VCCs and the fix. 
+    There was a commit implementing AES GCM cipher suites, a fix for the transport layer security authentication bug, and reporting of new error cases. 
+    While these are interesting, the issue here was that they missed an error case, and none of these commits lead to, assisted, or influenced this vulnerability.
   commits:
   - commit: 
     note: 

--- a/cves/CVE-2013-6628.yml
+++ b/cves/CVE-2013-6628.yml
@@ -137,6 +137,11 @@ interesting_commits:
     commit implementing AES GCM cipher suites and a 'fix' for the TLS authentication bug, supporting the build of NSS's libssl 
     as a component, reporting of new error cases, but the issue here was that they missed an error case, none of these commits 
     lead to or assisted or influenced this vulnerability.
+  commits:
+  - commit: 
+    note: 
+  - commit: 
+    note: 
 major_events:
   question: |
     Please record any major events you found in the history of this


### PR DESCRIPTION
adding the two CVE's I have researched, CVE-211-2850 is an issue with khmer characters. CVE-2013-6628 is an issue with not verifying a certificate during renegotiation of sockets