### PR TITLE
CVE-2015-1258 and CVE-2016-1634

### DIFF
--- a/cves/CVE-2015-1258.yml
+++ b/cves/CVE-2015-1258.yml
@@ -11,7 +11,7 @@ curated_instructions: |
   integrity checks on this file to make sure you fill everything out properly.
   If you are a student, we cannot accept your work as finished unless curated is
   set to true.
-curated: false
+curated: true
 announced_instructions: |
   Was there a date that this vulnerability was announced to the world? You can
   find this in changelogs, blogs, bug reports, or perhaps the CVE date. A good

--- a/cves/CVE-2015-1258.yml
+++ b/cves/CVE-2015-1258.yml
@@ -33,10 +33,10 @@ description_instructions: |
   expressions" is fine, and security phrases like "invalid write" are fine to
   keep too.
 description: |
-  A specific webm file was able to crash Chromium when opened in a tab because it caused a
+  A specific webm file was able to crash Chromium when opened in a tab. The webm caused a
   negative size parameter error in a Chromium dependency, libvpx. From what I can understand
   from the technical solution discussion on the issue report, this negative size parameter caused
-  a buffer overflow issue that could crash Chromium.
+  a buffer overflow.
 bounty_instructions: |
   If you came across any indications that a bounty was paid out for this
   vulnerability, fill it out here. Or correct it if the information already here
@@ -59,19 +59,13 @@ fixes_vcc_instructions: |
 fixes:
 - :commit: 89a36094df177a7fb50cfab571409b7bf91202a2
   :note: 'This commit updated the libvpx dependency version'
-- :commit: 89a36094df177a7fb50cfab571409b7bf91202a2
-  :note: 'This commit updated the libvpx dependency version'
 vccs:
-- :commit: none
+- :commit: fd5ba194dd83bace0a3623de2fae3fa7d2e5c6c8
   :note: |
     The changes in both fixing commits above update chromium to use a newer version of
     the libvpx dependency that has been updated to fix this CVE. The fixes themselves
     live within the libvpx repository and not in this chromium repository since it's an
-    external dependency. There are no VCCs within the Chromium repository, any that exist
-    would be within libvpx. The fixes to libvpx are detailed at 
-    https://bugs.chromium.org/p/chromium/issues/detail?id=450939#c23.
-    Specifically, the building of libvpx by the Chromium team did not set the size limit,
-    which allowed this vulnerability to exist. The fix sets the size limit when building libvpx.
+    external dependency. This VCC is the earliest commit I could find that adds libvpx as a Chromium dependency
 upvotes_instructions: |
   For the first round, ignore this upvotes number.
 
@@ -79,7 +73,7 @@ upvotes_instructions: |
   upvotes to each vulnerability you see. Your peers will tell you how
   interesting they think this vulnerability is, and you'll add that to the
   upvotes score on your branch.
-upvotes: 
+upvotes: 1
 unit_tested:
   question: |
     Were automated unit tests involved in this vulnerability?
@@ -93,9 +87,9 @@ unit_tested:
     For the "fix" answer below, check if the fix for the vulnerability involves
     adding or improving an automated test to ensure this doesn't happen again.
   answer: |
-    The fixing commit, located at https://codereview.chromium.org/1106303002 does
-    not include unit test changes. Because the code in question is in libvpx and
-    not Chromium I was unable to determine if the code had existing unit tests
+    The commit which fixed the issue, located at https://codereview.chromium.org/1106303002 does
+    not include unit test changes. Since the code in question is in libvpx and
+    not Chromium, I was unable to determine if the code had existing unit tests
     because there are no links to the files in question (vp9_deec_setup_mi,
     vp9_init_context_buffers, resize_context_buffers) at the issue page https://bugs.chromium.org/p/chromium/issues/detail?id=450939
   code: 
@@ -120,7 +114,7 @@ discovered:
     Chromium. The report does not give any details on the specifics of the webm and the file itself
     is not discussed in any of the reponses. It can be assumed that cloudfuzzer created the webm
     with the goal of causing a crash or other error in Chromium. It's not clear if the report
-    was automated or manual. Given the volume of reports by the user cloudfuzzer, it may be
+    was created automatically or manually. Given the volume of reports by the user cloudfuzzer, it may be
     automated.
   date: 2015-01-22
   automated: 
@@ -227,7 +221,7 @@ mistakes:
     every one. Write a thoughtful entry here that those ing the software
     engineering industry would find interesting.
   answer: |
-    On the libvpx side it's likely that there are some coding mistakes allowing such a vulernability to exist
+    On the libvpx side, it's likely that there are some coding mistakes allowing such a vulernability to exist
     or communication mistakes in not making the importance of the size limit flag not obvious enough. On the
     Chromium team's side, I would say that they were not thorough enough in their research of libvpx and the
     flags available to them when building it to be used within Chromium, as their omission of the size limit

--- a/cves/CVE-2015-1258.yml
+++ b/cves/CVE-2015-1258.yml
@@ -98,7 +98,7 @@ unit_tested:
     not Chromium I was unable to determine if the code had existing unit tests
     because there are no links to the files in question (vp9_deec_setup_mi,
     vp9_init_context_buffers, resize_context_buffers) at the issue page https://bugs.chromium.org/p/chromium/issues/detail?id=450939
-  code: nil
+  code: 
   fix: false
 discovered:
   question: |
@@ -123,7 +123,7 @@ discovered:
     was automated or manual. Given the volume of reports by the user cloudfuzzer, it may be
     automated.
   date: 2015-01-22
-  automated: nil
+  automated: 
   google: false
   contest: false
 subsystem:
@@ -146,7 +146,9 @@ interesting_commits:
     If there are no interesting commits, demonstrate that you completed this section by explaining what happened between the VCCs and the fix.
   answer: |
     Since there are no identifiable VCCs due to the error being in an external library, there are no interesting commits to be listed.
-  commits: nil
+  commits: 
+  - commit: 
+    note: 
 major_events:
   question: |
     Please record any major events you found in the history of this

--- a/cves/CVE-2015-1258.yml
+++ b/cves/CVE-2015-1258.yml
@@ -98,9 +98,8 @@ unit_tested:
     not Chromium I was unable to determine if the code had existing unit tests
     because there are no links to the files in question (vp9_deec_setup_mi,
     vp9_init_context_buffers, resize_context_buffers) at the issue page https://bugs.chromium.org/p/chromium/issues/detail?id=450939
-  code: 
-  fix: |
-    The fixing commit did not include changes or additions to automated testing.
+  code: nil
+  fix: false
 discovered:
   question: |
     How was this vulnerability discovered?
@@ -147,6 +146,7 @@ interesting_commits:
     If there are no interesting commits, demonstrate that you completed this section by explaining what happened between the VCCs and the fix.
   answer: |
     Since there are no identifiable VCCs due to the error being in an external library, there are no interesting commits to be listed.
+  commits: nil
 major_events:
   question: |
     Please record any major events you found in the history of this

--- a/cves/CVE-2015-1258.yml
+++ b/cves/CVE-2015-1258.yml
@@ -4,7 +4,7 @@ CWE_instructions: |
   Please go to cwe.mitre.org and find the most specific, appropriate CWE entry
   that describes your vulnerability. (Tip: this may not be a good one to start
   with - spend time understanding this vulnerability before making your choice!)
-CWE: 
+CWE: CWE-122
 curated_instructions: |
   If you are manually editing this file, then you are "curating" it. Set the
   entry below to "true" as soon as you start. This will enable additional
@@ -32,7 +32,11 @@ description_instructions: |
   that outsiders to Chromium would not understand. Technology like "regular
   expressions" is fine, and security phrases like "invalid write" are fine to
   keep too.
-description: 
+description: |
+  A specific webm file was able to crash Chromium when opened in a tab because it caused a
+  negative size parameter error in a Chromium dependency, libvpx. From what I can understand
+  from the technical solution discussion on the issue report, this negative size parameter caused
+  a buffer overflow issue that could crash Chromium.
 bounty_instructions: |
   If you came across any indications that a bounty was paid out for this
   vulnerability, fill it out here. Or correct it if the information already here
@@ -54,12 +58,20 @@ fixes_vcc_instructions: |
   CVE-2011-3092.yml). Fixes and VCCs follow the same format.
 fixes:
 - :commit: 89a36094df177a7fb50cfab571409b7bf91202a2
-  :note: ''
+  :note: 'This commit updated the libvpx dependency version'
 - :commit: 89a36094df177a7fb50cfab571409b7bf91202a2
-  :note: ''
+  :note: 'This commit updated the libvpx dependency version'
 vccs:
-- :commit:
-  :note: 
+- :commit: none
+  :note: |
+    The changes in both fixing commits above update chromium to use a newer version of
+    the libvpx dependency that has been updated to fix this CVE. The fixes themselves
+    live within the libvpx repository and not in this chromium repository since it's an
+    external dependency. There are no VCCs within the Chromium repository, any that exist
+    would be within libvpx. The fixes to libvpx are detailed at 
+    https://bugs.chromium.org/p/chromium/issues/detail?id=450939#c23.
+    Specifically, the building of libvpx by the Chromium team did not set the size limit,
+    which allowed this vulnerability to exist. The fix sets the size limit when building libvpx.
 upvotes_instructions: |
   For the first round, ignore this upvotes number.
 
@@ -80,9 +92,15 @@ unit_tested:
 
     For the "fix" answer below, check if the fix for the vulnerability involves
     adding or improving an automated test to ensure this doesn't happen again.
-  answer: 
+  answer: |
+    The fixing commit, located at https://codereview.chromium.org/1106303002 does
+    not include unit test changes. Because the code in question is in libvpx and
+    not Chromium I was unable to determine if the code had existing unit tests
+    because there are no links to the files in question (vp9_deec_setup_mi,
+    vp9_init_context_buffers, resize_context_buffers) at the issue page https://bugs.chromium.org/p/chromium/issues/detail?id=450939
   code: 
-  fix: 
+  fix: |
+    The fixing commit did not include changes or additions to automated testing.
 discovered:
   question: |
     How was this vulnerability discovered?
@@ -98,11 +116,17 @@ discovered:
 
     If there is no evidence as to how this vulnerability was found, then you may
     leave the entries blank except for "answer". Write down where you looked in "answer".
-  answer: 
-  date: 
-  automated: 
-  google: 
-  contest: 
+  answer: |
+    The bug was reported by cloudfuzzer, and it was found by opening a specific .webm file in
+    Chromium. The report does not give any details on the specifics of the webm and the file itself
+    is not discussed in any of the reponses. It can be assumed that cloudfuzzer created the webm
+    with the goal of causing a crash or other error in Chromium. It's not clear if the report
+    was automated or manual. Given the volume of reports by the user cloudfuzzer, it may be
+    automated.
+  date: 2015-01-22
+  automated: nil
+  google: false
+  contest: false
 subsystem:
   question: |
     What subsystems was the mistake in?
@@ -110,7 +134,7 @@ subsystem:
     Look at the path of the source code files code that were fixed to get
     directory names. Look at comments in the code. Look at the bug reports how
     the bug report was tagged. Examples: "clipboard", "gpu", "ssl", "speech", "renderer"
-  answer: 
+  answer: The mistake was in the building of a dependency, libvpx
   name: 
 interesting_commits:
   question: |
@@ -121,12 +145,8 @@ interesting_commits:
     emerging themes?
 
     If there are no interesting commits, demonstrate that you completed this section by explaining what happened between the VCCs and the fix.
-  answer:
-  commits:
-  - commit: 
-    note: 
-  - commit: 
-    note: 
+  answer: |
+    Since there are no identifiable VCCs due to the error being in an external library, there are no interesting commits to be listed.
 major_events:
   question: |
     Please record any major events you found in the history of this
@@ -135,12 +155,10 @@ major_events:
 
     The event doesn't need to be directly related to this vulnerability, rather,
     we want to capture what the development team was dealing with at the time.
-  answer: 
-  events:
-  - name: 
-    date: 
-  - name: 
-    date: 
+  answer: |
+    Again, this vulnerability is caused by the Chromium team's build process for libvpx and was solved by adding another flag to the build.
+    Due to the simplicity of this fix, I find it unlikely that any major events took place that caused or had an effect on this. Simply,
+    a flag was not included that turned out to be important to avoiding buffer overflows.
 lessons:
   question: |
     Are there any common lessons we have learned from class that apply to this
@@ -157,37 +175,42 @@ lessons:
     If you think of another lesson we covered in class that applies here, feel
     free to give it a small name and add one in the same format as these.
   defense_in_depth:
-    applies: 
+    applies: false
     note: 
   least_privilege:
-    applies: 
+    applies: false
     note: 
   frameworks_are_optional:
-    applies: 
+    applies: false
     note: 
   native_wrappers:
-    applies: 
+    applies: false
     note: 
   distrust_input:
-    applies: 
+    applies: false
     note: 
   security_by_obscurity:
-    applies: 
+    applies: false
     note: 
   serial_killer:
-    applies: 
+    applies: false
     note: 
   environment_variables:
-    applies: 
+    applies: false
     note: 
   secure_by_default:
-    applies: 
-    note: 
+    applies: true
+    note: |
+      The fix was simply to specify the size limit of libvpx when building it to prevent overflows.
+      It's reasonable to say that if such a vulnerability exists when the flag is not specified, it should
+      be a required flag. The exclusion of it allowed for this vulnerability to exist, while making the flag
+      required and well documented could have allowed the Chromium team to avoid the vulnerability's creation
+      upon their addition of libvpx to Chromium.
   yagni:
-    applies: 
+    applies: false
     note: 
   complex_inputs:
-    applies: 
+    applies: false
     note: 
 mistakes:
   question: |
@@ -201,4 +224,10 @@ mistakes:
     Use those questions to inspire your answer. Don't feel obligated to answer
     every one. Write a thoughtful entry here that those ing the software
     engineering industry would find interesting.
-  answer: 
+  answer: |
+    On the libvpx side it's likely that there are some coding mistakes allowing such a vulernability to exist
+    or communication mistakes in not making the importance of the size limit flag not obvious enough. On the
+    Chromium team's side, I would say that they were not thorough enough in their research of libvpx and the
+    flags available to them when building it to be used within Chromium, as their omission of the size limit
+    allowed for this vulnerability. Since this is a very niche vulnerability mainly caused by configuration
+    issues of a third party dependency, the mitigations for the CWE are not particularly relevant or useful.

--- a/cves/CVE-2016-1634.yml
+++ b/cves/CVE-2016-1634.yml
@@ -11,7 +11,7 @@ curated_instructions: |
   integrity checks on this file to make sure you fill everything out properly.
   If you are a student, we cannot accept your work as finished unless curated is
   set to true.
-curated: false
+curated: true
 announced_instructions: |
   Was there a date that this vulnerability was announced to the world? You can
   find this in changelogs, blogs, bug reports, or perhaps the CVE date. A good

--- a/cves/CVE-2016-1634.yml
+++ b/cves/CVE-2016-1634.yml
@@ -4,7 +4,7 @@ CWE_instructions: |
   Please go to cwe.mitre.org and find the most specific, appropriate CWE entry
   that describes your vulnerability. (Tip: this may not be a good one to start
   with - spend time understanding this vulnerability before making your choice!)
-CWE: 
+CWE: CWE-416
 curated_instructions: |
   If you are manually editing this file, then you are "curating" it. Set the
   entry below to "true" as soon as you start. This will enable additional
@@ -32,7 +32,14 @@ description_instructions: |
   that outsiders to Chromium would not understand. Technology like "regular
   expressions" is fine, and security phrases like "invalid write" are fine to
   keep too.
-description: 
+description: |
+  A set of JavaScript creats an input element inside a form element and adds them to the DOM,
+  then forces a style recalculation and removes the input from the form element. Due to the
+  synchronous order of execution that should have been asynchronous, it would cause a use-after-free
+  error, where a memory address that has been freed is attempted to be accessed, because the style
+  recalculation and element removal are executed in the wrong order.
+
+  This vulernability exists in the third party WebKit source.
 bounty_instructions: |
   If you came across any indications that a bounty was paid out for this
   vulnerability, fill it out here. Or correct it if the information already here
@@ -52,10 +59,16 @@ fixes_vcc_instructions: |
   CVE-2011-3092.yml). Fixes and VCCs follow the same format.
 fixes:
 - :commit: 0b0f3ace8820d371e6f4b2b61354728a71ce8356
-  :note: ''
+  :note: 'This commit adds a check for the error case and returns the function early if it will occur'
 vccs:
-- :commit:
-  :note: 
+- :commit: 7b0afec9845caaabe0b7f8e7d195ea70438df523
+  :note: |
+    The commit adds most of the surrounding code, including the use of the treeScope, which is where the
+    use-after-free error occurs.
+- :commit: 5aafe0dbc8bd3bc2e0579d9190b4eb1db7908032
+  :note: |
+    This commit adds the code that calls the style sheet changes in which the actual use-after-free error
+    most likely occurs. 
 upvotes_instructions: |
   For the first round, ignore this upvotes number.
 
@@ -76,9 +89,13 @@ unit_tested:
 
     For the "fix" answer below, check if the fix for the vulnerability involves
     adding or improving an automated test to ensure this doesn't happen again.
-  answer: 
-  code: 
-  fix: 
+  answer: |
+    The fixing commit includes an html file with a script tag that includes the
+    JavaScript that caused the use-after-free error. It is a simplified version of the
+    JavaScript originally submitted by cloudfuzzer, who reported the vulnerability. It
+    is used in automated tests to check if Chromium crashes when opening the html file.
+  code: The original code was unit tested but this vulnerability is a new test case that was not being tested.
+  fix: As stated above it includes a new unit test.
 discovered:
   question: |
     How was this vulnerability discovered?
@@ -94,11 +111,15 @@ discovered:
 
     If there is no evidence as to how this vulnerability was found, then you may
     leave the entries blank except for "answer". Write down where you looked in "answer".
-  answer: 
-  date: 
-  automated: 
-  google: 
-  contest: 
+  answer: |
+    This vulnerability was reported by the user cloudfuzzer, and it appears that JavaScript
+    was manually written to find this vulernability. Given the volume of reports that the user,
+    cloudfuzzer, submits, and the names of the variables used in the exploit code, it's also possible
+    that this was automated in some fashion. Since it's unclear if it was automated, I've marked automated as nil.
+  date: 2016-01-12
+  automated: nil
+  google: false
+  contest: false
 subsystem:
   question: |
     What subsystems was the mistake in?
@@ -106,8 +127,8 @@ subsystem:
     Look at the path of the source code files code that were fixed to get
     directory names. Look at comments in the code. Look at the bug reports how
     the bug report was tagged. Examples: "clipboard", "gpu", "ssl", "speech", "renderer"
-  answer: 
-  name: 
+  answer:
+    name: WebKit
 interesting_commits:
   question: |
     Are there any interesting commits between your VCC(s) and fix(es)?
@@ -117,12 +138,7 @@ interesting_commits:
     emerging themes?
 
     If there are no interesting commits, demonstrate that you completed this section by explaining what happened between the VCCs and the fix.
-  answer:
-  commits:
-  - commit: 
-    note: 
-  - commit: 
-    note: 
+  answer: The VCC commits were the last commits to the affected code, so there are no interesting commits between the VCCs and the fix.
 major_events:
   question: |
     Please record any major events you found in the history of this
@@ -131,12 +147,10 @@ major_events:
 
     The event doesn't need to be directly related to this vulnerability, rather,
     we want to capture what the development team was dealing with at the time.
-  answer: 
-  events:
-  - name: 
-    date: 
-  - name: 
-    date: 
+  answer: |
+    There is no evidence from the issue report thread that any major events happened that influenced this vulnerability.
+    This is a simple case where an edge case was not thought of or tested, and a third party user tested it and discovered
+    a vulnerability.
 lessons:
   question: |
     Are there any common lessons we have learned from class that apply to this
@@ -153,38 +167,46 @@ lessons:
     If you think of another lesson we covered in class that applies here, feel
     free to give it a small name and add one in the same format as these.
   defense_in_depth:
-    applies: 
+    applies: false
     note: 
   least_privilege:
-    applies: 
+    applies: false
     note: 
   frameworks_are_optional:
-    applies: 
+    applies: false
     note: 
   native_wrappers:
-    applies: 
+    applies: false
     note: 
   distrust_input:
-    applies: 
+    applies: false
     note: 
   security_by_obscurity:
-    applies: 
+    applies: false
     note: 
   serial_killer:
-    applies: 
+    applies: false
     note: 
   environment_variables:
-    applies: 
+    applies: false
     note: 
   secure_by_default:
-    applies: 
+    applies: false
     note: 
   yagni:
-    applies: 
+    applies: false
     note: 
   complex_inputs:
-    applies: 
-    note: 
+    applies: true
+    note: |
+      The vulnerability applies to a component that interprets client side JavaScript.
+      User-inputted code may be the most complex inputs possible, so of course there are
+      many subtle vulnerabilities, like this one, that arise when dealing with user-inputted
+      code. In this case, WebKit encountered a use-after-free error due to the order of operation calls
+      by a specific set of JavaScript. WebKit was updated to handle these calls asynchronously and in the
+      correct order, but given the infinite combinations of JavaScript calls that can be made there is no
+      way to make WebKit vulnerability-free, the team can only continually improve its resistance to these
+      types of vulnerabilities.
 mistakes:
   question: |
     In your opinion, after all of this research, what mistakes were made that
@@ -197,4 +219,15 @@ mistakes:
     Use those questions to inspire your answer. Don't feel obligated to answer
     every one. Write a thoughtful entry here that those ing the software
     engineering industry would find interesting.
-  answer: 
+  answer: |
+    There seems to be a design/code mistake in the processing of the DOM operations,
+    in that operations that should be handled in the correct asynchronous order were handled
+    synchronously which allowed for operations to occur in an invalid order that caused the
+    use-after-free error. The mitigations offered on the use-after-free CWE suggest using a
+    language that offers automatic memory management. For WebKit, performance is key so the use
+    of C++ makes sense, whereas using a language that manages memory automatically would
+    hinder performance too much, so it's not a valid mitigation or one that the WebKit team
+    practices. The second mitigation suggests setting pointers to NULL after freeing them.
+    Based on the results of the vulnerability's exploit case, it seems that this was not being
+    practiced in the code, although I was not able to find a concrete example in the code
+    due to its complexity.

--- a/cves/CVE-2016-1634.yml
+++ b/cves/CVE-2016-1634.yml
@@ -33,10 +33,10 @@ description_instructions: |
   expressions" is fine, and security phrases like "invalid write" are fine to
   keep too.
 description: |
-  A set of JavaScript creats an input element inside a form element and adds them to the DOM,
+  A JavaScript script creates an input element inside a form element and adds them to the DOM (web page),
   then forces a style recalculation and removes the input from the form element. Due to the
   synchronous order of execution that should have been asynchronous, it would cause a use-after-free
-  error, where a memory address that has been freed is attempted to be accessed, because the style
+  error. This occurs becausehere a memory address that has been freed is attempted to be accessed, because the style
   recalculation and element removal are executed in the wrong order.
 
   This vulernability exists in the third party WebKit source.
@@ -76,7 +76,7 @@ upvotes_instructions: |
   upvotes to each vulnerability you see. Your peers will tell you how
   interesting they think this vulnerability is, and you'll add that to the
   upvotes score on your branch.
-upvotes: 
+upvotes: 4
 unit_tested:
   question: |
     Were automated unit tests involved in this vulnerability?
@@ -85,7 +85,7 @@ unit_tested:
 
     For the "code" answer below, look not only at the fix but the surrounding
     code near the fix and determine if and was there were unit tests involved
-    for this module.S
+    for this module.
 
     For the "fix" answer below, check if the fix for the vulnerability involves
     adding or improving an automated test to ensure this doesn't happen again.
@@ -129,7 +129,7 @@ subsystem:
     directory names. Look at comments in the code. Look at the bug reports how
     the bug report was tagged. Examples: "clipboard", "gpu", "ssl", "speech", "renderer"
   answer:
-    name: WebKit
+  name: WebKit
 interesting_commits:
   question: |
     Are there any interesting commits between your VCC(s) and fix(es)?
@@ -204,12 +204,12 @@ lessons:
     applies: true
     note: |
       The vulnerability applies to a component that interprets client side JavaScript.
-      User-inputted code may be the most complex inputs possible, so of course there are
-      many subtle vulnerabilities, like this one, that arise when dealing with user-inputted
-      code. In this case, WebKit encountered a use-after-free error due to the order of operation calls
+      User-inputted code may be the most complex inputs possible. Naturally there are
+      many subtle vulnerabilities, like this one, that arise when dealing with it. In
+      this case, WebKit encountered a use-after-free error due to the order of operation calls
       by a specific set of JavaScript. WebKit was updated to handle these calls asynchronously and in the
-      correct order, but given the infinite combinations of JavaScript calls that can be made there is no
-      way to make WebKit vulnerability-free, the team can only continually improve its resistance to these
+      correct order. Given the infinite combinations of JavaScript calls that can be made there is no
+      way to make WebKit vulnerability-free. The team can only continually improve its resistance to these
       types of vulnerabilities.
 mistakes:
   question: |
@@ -224,14 +224,14 @@ mistakes:
     every one. Write a thoughtful entry here that those ing the software
     engineering industry would find interesting.
   answer: |
-    There seems to be a design/code mistake in the processing of the DOM operations,
-    in that operations that should be handled in the correct asynchronous order were handled
+    There seems to be a design/code mistake in the processing of the DOM operations.
+    Ooperations that should be handled in the correct asynchronous order were handled
     synchronously which allowed for operations to occur in an invalid order that caused the
     use-after-free error. The mitigations offered on the use-after-free CWE suggest using a
     language that offers automatic memory management. For WebKit, performance is key so the use
     of C++ makes sense, whereas using a language that manages memory automatically would
-    hinder performance too much, so it's not a valid mitigation or one that the WebKit team
+    hinder performance too much. Therefore, it's not a valid mitigation or one that the WebKit team
     practices. The second mitigation suggests setting pointers to NULL after freeing them.
     Based on the results of the vulnerability's exploit case, it seems that this was not being
-    practiced in the code, although I was not able to find a concrete example in the code
+    practiced in the code. I was not able to find a concrete example in the code
     due to its complexity.

--- a/cves/CVE-2016-1634.yml
+++ b/cves/CVE-2016-1634.yml
@@ -94,8 +94,9 @@ unit_tested:
     JavaScript that caused the use-after-free error. It is a simplified version of the
     JavaScript originally submitted by cloudfuzzer, who reported the vulnerability. It
     is used in automated tests to check if Chromium crashes when opening the html file.
-  code: The original code was unit tested but this vulnerability is a new test case that was not being tested.
-  fix: As stated above it includes a new unit test.
+    The original code was unit tested but this vulnerability is a new test case that was not being tested.
+  code: true
+  fix: true
 discovered:
   question: |
     How was this vulnerability discovered?
@@ -139,6 +140,7 @@ interesting_commits:
 
     If there are no interesting commits, demonstrate that you completed this section by explaining what happened between the VCCs and the fix.
   answer: The VCC commits were the last commits to the affected code, so there are no interesting commits between the VCCs and the fix.
+  commits: nil
 major_events:
   question: |
     Please record any major events you found in the history of this

--- a/cves/CVE-2016-1634.yml
+++ b/cves/CVE-2016-1634.yml
@@ -85,7 +85,7 @@ unit_tested:
 
     For the "code" answer below, look not only at the fix but the surrounding
     code near the fix and determine if and was there were unit tests involved
-    for this module.
+    for this module.S
 
     For the "fix" answer below, check if the fix for the vulnerability involves
     adding or improving an automated test to ensure this doesn't happen again.
@@ -118,7 +118,7 @@ discovered:
     cloudfuzzer, submits, and the names of the variables used in the exploit code, it's also possible
     that this was automated in some fashion. Since it's unclear if it was automated, I've marked automated as nil.
   date: 2016-01-12
-  automated: nil
+  automated: 
   google: false
   contest: false
 subsystem:
@@ -140,7 +140,9 @@ interesting_commits:
 
     If there are no interesting commits, demonstrate that you completed this section by explaining what happened between the VCCs and the fix.
   answer: The VCC commits were the last commits to the affected code, so there are no interesting commits between the VCCs and the fix.
-  commits: nil
+  commits: 
+  - commit: 
+    note: 
 major_events:
   question: |
     Please record any major events you found in the history of this

--- a/cves/CVE-2016-1634.yml
+++ b/cves/CVE-2016-1634.yml
@@ -129,7 +129,7 @@ subsystem:
     directory names. Look at comments in the code. Look at the bug reports how
     the bug report was tagged. Examples: "clipboard", "gpu", "ssl", "speech", "renderer"
   answer:
-  name: WebKit
+    name: WebKit
 interesting_commits:
   question: |
     Are there any interesting commits between your VCC(s) and fix(es)?


### PR DESCRIPTION
This PR explores CVE-2015-1258, a negative-size parameter issue which caused a buffer overflow vulnerability in libvpx, and CVE-2016-1634, a use-after-free vulnerability in WebKit.