### PR TITLE
CVE-2010-0660 and CVE-2016-1631

### DIFF
--- a/cves/CVE-2010-0660.yml
+++ b/cves/CVE-2010-0660.yml
@@ -94,8 +94,8 @@ unit_tested:
     For the "fix" answer below, check if the fix for the vulnerability involves
     adding or improving an automated test to ensure this doesn't happen again.
   answer: |
-    From looking at the fix code it's clear that code was tested and they added
-    a new unit test for validating the fix.
+    From looking at the fix code it is clear that the code was tested and that 
+    there were new unit tests for validating the fix.
   code: true
   fix: true
 discovered:
@@ -114,7 +114,7 @@ discovered:
     If there is no evidence as to how this vulnerability was found, then you may
     leave the entries blank except for "answer". Write down where you looked in "answer".
   answer: |
-    Found by manually by examining the redirect header after first visiting a URL 
+    Found by manually examining the referrer header after first visiting a URL 
     secured by HTTPS and then clicking a secure HTTPS link that triggers a redirect 
     to an unsecure HTTP URL.
   date: 2009-12-09
@@ -143,10 +143,10 @@ interesting_commits:
   commits:
   - commit: e600c8212f8922d77815316ff41fd8ce9d95bca7
     note: |
-      They added a method to sanatize the referrer header to remove potential usernames 
+      They added a method to sanitize the referrer header to remove potential usernames 
       and passwords. It is not clear from the issue referenced if this change was for 
       automated testing purposes only or if this was an attempt to mitigate leaking sensitive data
-      in the referrer in the field.
+      in the wild.
   - commit: 6568a9e384e0f92422c68d4f31fb401df4acbaed
     note: |
       They worked on some CSRF issues with following a temporary redirect (307 error) for a moved URL.
@@ -250,7 +250,7 @@ mistakes:
     The CWE vulnerability mitigations suggest that this could have been avoided
     in the Architecture and Design phase by drawing unambiguous trust boundaries.
     It would be interesting to see if there were updates to security related
-    design documentation to show how a redirect can be used leave a site
+    design documentation to show how a redirect can be used to leave a site
     secured by HTTPS. 
     
     The fix itself appears well enough, but it is hard to tell if there was a lesson 

--- a/cves/CVE-2010-0660.yml
+++ b/cves/CVE-2010-0660.yml
@@ -4,21 +4,21 @@ CWE_instructions: |
   Please go to cwe.mitre.org and find the most specific, appropriate CWE entry
   that describes your vulnerability. (Tip: this may not be a good one to start
   with - spend time understanding this vulnerability before making your choice!)
-CWE: 
+CWE: 201
 curated_instructions: |
   If you are manually editing this file, then you are "curating" it. Set the
   entry below to "true" as soon as you start. This will enable additional
   integrity checks on this file to make sure you fill everything out properly.
   If you are a student, we cannot accept your work as finished unless curated is
   set to true.
-curated: false
+curated: true
 announced_instructions: |
   Was there a date that this vulnerability was announced to the world? You can
   find this in changelogs, blogs, bug reports, or perhaps the CVE date. A good
   source for this is Chrome's Stable Release Channel
   (https://chromereleases.googleblog.com/).
   Please enter your date in YYYY-MM-DD format.
-announced: 2010-02-18 13:00:00.987000000 -05:00
+announced: 2010-01-25
 description_instructions: |
   You can get an initial description from the CVE entry on cve.mitre.org. These
   descriptions are a fine start, but they can be kind of jargony.
@@ -32,7 +32,16 @@ description_instructions: |
   that outsiders to Chromium would not understand. Technology like "regular
   expressions" is fine, and security phrases like "invalid write" are fine to
   keep too.
-description: 
+description: |
+  Chromium sends an HTTPS URL in the Referer header to an HTTP site when redirecting
+  from a secure HTTPS site to an unsecure HTTP site. 
+  
+  The 'Referer' header is the address of the previous web page from which a link 
+  to the currently requested page was followed. An unsecure HTTP site may obtain 
+  sensitive information embedded in the HTTPS URL such as password reset links.
+
+  Even if the security of the site is not compromised, the user of the site may 
+  not want the information shared.
 bounty_instructions: |
   If you came across any indications that a bounty was paid out for this
   vulnerability, fill it out here. Or correct it if the information already here
@@ -54,12 +63,16 @@ fixes_vcc_instructions: |
   CVE-2011-3092.yml). Fixes and VCCs follow the same format.
 fixes:
 - :commit: 7844480ae4f50930ca66fd3658790b52d344826d
-  :note: ''
+  :note: Fixing commit
 - :commit: f8bc33be983c60bdd7de7a34fc76cc7ddd2f7dfd
-  :note: ''
+  :note: Updated test expectations
 vccs:
-- :commit:
-  :note: 
+- :commit: 586acc5fe142f498261f52c66862fa417c3d52d2
+  :note: | 
+    The vulnerability was present from the start of the repository.
+    It is clear that from the start it was known that a HTTPS url should
+    not be sent as the referrer for a HTTP request; however, the redirect
+    edge case was not handled.
 upvotes_instructions: |
   For the first round, ignore this upvotes number.
 
@@ -80,9 +93,11 @@ unit_tested:
 
     For the "fix" answer below, check if the fix for the vulnerability involves
     adding or improving an automated test to ensure this doesn't happen again.
-  answer: 
-  code: 
-  fix: 
+  answer: |
+    From looking at the fix code it's clear that code was tested and they added
+    a new unit test for validating the fix.
+  code: true
+  fix: true
 discovered:
   question: |
     How was this vulnerability discovered?
@@ -98,11 +113,14 @@ discovered:
 
     If there is no evidence as to how this vulnerability was found, then you may
     leave the entries blank except for "answer". Write down where you looked in "answer".
-  answer: 
-  date: 
-  automated: 
-  google: 
-  contest: 
+  answer: |
+    Found by manually by examining the redirect header after first visiting a URL 
+    secured by HTTPS and then clicking a secure HTTPS link that triggers a redirect 
+    to an unsecure HTTP URL.
+  date: 2009-12-09
+  automated: false
+  google: true
+  contest: false
 subsystem:
   question: |
     What subsystems was the mistake in?
@@ -110,8 +128,8 @@ subsystem:
     Look at the path of the source code files code that were fixed to get
     directory names. Look at comments in the code. Look at the bug reports how
     the bug report was tagged. Examples: "clipboard", "gpu", "ssl", "speech", "renderer"
-  answer: 
-  name: 
+  answer: Based on the Issue report and source code.
+  name: Internals, url_request
 interesting_commits:
   question: |
     Are there any interesting commits between your VCC(s) and fix(es)?
@@ -123,10 +141,18 @@ interesting_commits:
     If there are no interesting commits, demonstrate that you completed this section by explaining what happened between the VCCs and the fix.
   answer:
   commits:
-  - commit: 
-    note: 
-  - commit: 
-    note: 
+  - commit: e600c8212f8922d77815316ff41fd8ce9d95bca7
+    note: |
+      They added a method to sanatize the referrer header to remove potential usernames 
+      and passwords. It is not clear from the issue referenced if this change was for 
+      automated testing purposes only or if this was an attempt to mitigate leaking sensitive data
+      in the referrer in the field.
+  - commit: 6568a9e384e0f92422c68d4f31fb401df4acbaed
+    note: |
+      They worked on some CSRF issues with following a temporary redirect (307 error) for a moved URL.
+      It appears that the redirect allowed for custom headers and body of the original request
+      to be re-transmitted to the victim site which could result in session hijacking and
+      loss of sensitive information.
 major_events:
   question: |
     Please record any major events you found in the history of this
@@ -181,14 +207,25 @@ lessons:
     applies: 
     note: 
   secure_by_default:
-    applies: 
-    note: 
+    applies: true
+    note: |
+      Instead of relying on the server to clear possible sensitive data from the
+      referrer, the browser does this as a default.
   yagni:
     applies: 
     note: 
   complex_inputs:
-    applies: 
-    note: 
+    applies:
+    note:
+  cognitive_complexity:
+    applies: true
+    note: |
+      The vulnerability involves dependencies on server implementations 
+      outside the control of the browser's developers. The developers have to 
+      brainstorm the possible usages of the referrer header as well as in what 
+      cases it should and should not be sent with a request. This is further 
+      complicated by the number of methods a request can occur and by the number
+      of protocols handled by the browser. 
 mistakes:
   question: |
     In your opinion, after all of this research, what mistakes were made that
@@ -201,4 +238,25 @@ mistakes:
     Use those questions to inspire your answer. Don't feel obligated to answer
     every one. Write a thoughtful entry here that those ing the software
     engineering industry would find interesting.
-  answer: 
+  answer: |
+    The mistake was essentially not handling an edge case where a request
+    was made from a secure site to an unsecure site using a redirect. The fix
+    itself was only 2 lines of code to check to see if the referrer header should 
+    be cleared before redirecting. It was clear that the developer's knew from the
+    beginning of the repository that the referrer should not be sent from an HTTPS 
+    site to an HTTP, and did not in other cases, but this was not implemented in 
+    redirecting.
+
+    The CWE vulnerability mitigations suggest that this could have been avoided
+    in the Architecture and Design phase by drawing unambiguous trust boundaries.
+    It would be interesting to see if there were updates to security related
+    design documentation to show how a redirect can be used leave a site
+    secured by HTTPS. 
+    
+    The fix itself appears well enough, but it is hard to tell if there was a lesson 
+    learned by the developers from this mistake since it is unclear why this case
+    was missed (other than just complexity). It is not even safe to say that all
+    instances of the referrer crossing trust boundaries are handeled or that future
+    functionality will not repeat the same mistakes.
+
+

--- a/cves/CVE-2010-0660.yml
+++ b/cves/CVE-2010-0660.yml
@@ -80,7 +80,7 @@ upvotes_instructions: |
   upvotes to each vulnerability you see. Your peers will tell you how
   interesting they think this vulnerability is, and you'll add that to the
   upvotes score on your branch.
-upvotes: 
+upvotes: 8
 unit_tested:
   question: |
     Were automated unit tests involved in this vulnerability?
@@ -224,7 +224,7 @@ lessons:
       outside the control of the browser's developers. The developers have to 
       brainstorm the possible usages of the referrer header as well as in what 
       cases it should and should not be sent with a request. This is further 
-      complicated by the number of methods a request can occur and by the number
+      complicated by the number of methods a request can use and by the number
       of protocols handled by the browser. 
 mistakes:
   question: |

--- a/cves/CVE-2016-1631.yml
+++ b/cves/CVE-2016-1631.yml
@@ -107,7 +107,7 @@ discovered:
     leave the entries blank except for "answer". Write down where you looked in "answer".
   answer: |
     It is not clear how this vulnerability was discoverd, if by manual inspection
-    by fuzzer; however, it was reproduced manually using an exploit provided in
+    or by fuzzer; however, it was reproduced manually using an exploit provided in
     the issue report.
   date: 2015-12-14
   automated:
@@ -143,12 +143,12 @@ interesting_commits:
       with arbitrary script execution within modal loops.
   - commit: b5717a4f9f66283a9fe04ae1f9a3a89920d5b6b0
     note: |
-      The task handler system that is used to run recursive message modal loop was 
-      updated to make nested message loops safer. However, the developers added warnings 
-      in the comments that in general nestable message loops should be avoided because
+      The task handler system that is used to run recursive message modal loops was 
+      updated to make nested message loops safer. The developers even added warnings 
+      in the comments that, in general, nestable message loops should be avoided because
       they are dangerous and difficult to get right.
 
-      In this commit, the vulnerable Flash Message Loop was updated to use the updated
+      In this commit the vulnerable Flash Message Loop was updated to use the updated
       task handler.
 major_events:
   question: |
@@ -185,7 +185,7 @@ lessons:
   least_privilege:
     applies: true 
     note: |
-      The nested modals allowed were allowed to bypass the the Same Origin Policy.
+      The nested message modals were allowed to bypass the the Same Origin Policy.
   frameworks_are_optional:
     applies: 
     note: 
@@ -219,7 +219,7 @@ lessons:
     applies: true
     note: |
       The vulnerability involves the use of many different components inside of a 
-      recursive loop which may cause state changes. State has to be handeled carefully
+      recursive loop that may cause state changes. The state has to be handeled carefully
       in order to provide protections inside the nested loop and then restore functionality
       once the loop has ended.
 mistakes:
@@ -240,12 +240,12 @@ mistakes:
     two methods used to mitigate this vulnerability were in the repository for 
     six years before it was discovered.
 
-    It appears that trust boundaries were drawn, but not around all the components
+    It appears that trust boundaries were drawn, but not around all of the components
     that may cross it. Proper analysis of the architecture is really the only mitigation
     against this kind of vulnerability. Since this vulnerability was found by someone
-    outside the chromium team, it is unclear if this has been done.
+    outside the Chromium team, it is unclear if this has been done.
     
     The lesson to be learned here is that it is not good enough to discover a 
-    possible attack vector and fix it in place and just apply this knowledge to
+    possible attack vector and fix it in place and then apply this knowledge to
     future development. This knowledge needs to be applied to the existing code
     base as well.

--- a/cves/CVE-2016-1631.yml
+++ b/cves/CVE-2016-1631.yml
@@ -4,21 +4,21 @@ CWE_instructions: |
   Please go to cwe.mitre.org and find the most specific, appropriate CWE entry
   that describes your vulnerability. (Tip: this may not be a good one to start
   with - spend time understanding this vulnerability before making your choice!)
-CWE: 
+CWE: 284
 curated_instructions: |
   If you are manually editing this file, then you are "curating" it. Set the
   entry below to "true" as soon as you start. This will enable additional
   integrity checks on this file to make sure you fill everything out properly.
   If you are a student, we cannot accept your work as finished unless curated is
   set to true.
-curated: false
+curated: true
 announced_instructions: |
   Was there a date that this vulnerability was announced to the world? You can
   find this in changelogs, blogs, bug reports, or perhaps the CVE date. A good
   source for this is Chrome's Stable Release Channel
   (https://chromereleases.googleblog.com/).
   Please enter your date in YYYY-MM-DD format.
-announced: 2016-03-05 21:59:02.197000000 -05:00
+announced: 2016-03-02
 description_instructions: |
   You can get an initial description from the CVE entry on cve.mitre.org. These
   descriptions are a fine start, but they can be kind of jargony.
@@ -32,13 +32,21 @@ description_instructions: |
   that outsiders to Chromium would not understand. Technology like "regular
   expressions" is fine, and security phrases like "invalid write" are fine to
   keep too.
-description: 
+description: |
+  The vulnerability was in Google's Flash Player module, *Pepper*, in the way the
+  Flash Message Modal (basically windowless pop-ups) handled nested modals.
+
+  The implementation did not suspend script callbacks or resource loads inside
+  the nested modal box. As a result, cross-origin documents could be loaded from
+  an arbitrary Javascript execution point. This vulnerability bypasses the Same
+  Origin Policy and could be used to cause denial of service, loss of sensitive 
+  information, and execution of arbitrary code.
 bounty_instructions: |
   If you came across any indications that a bounty was paid out for this
   vulnerability, fill it out here. Or correct it if the information already here
   was wrong. Otherwise, leave it blank.
 bounty:
-  date: 2016-03-02 15:41:00.000000000 -05:00
+  date: 2016-03-02
   amount: 7500.0
   references:
   - http://chromereleases.googleblog.com/2016/03/stable-channel-update.html
@@ -53,10 +61,10 @@ fixes_vcc_instructions: |
   CVE-2011-3092.yml). Fixes and VCCs follow the same format.
 fixes:
 - :commit: dd77c2a41c72589d929db0592565125ca629fb2c
-  :note: ''
+  :note:
 vccs:
-- :commit:
-  :note: 
+- :commit: cd2af395e8429a30bcee9e7ad7ec9f4b680c924d
+  :note:
 upvotes_instructions: |
   For the first round, ignore this upvotes number.
 
@@ -77,9 +85,11 @@ unit_tested:
 
     For the "fix" answer below, check if the fix for the vulnerability involves
     adding or improving an automated test to ensure this doesn't happen again.
-  answer: 
-  code: 
-  fix: 
+  answer: | 
+    It is clear from the code that there were unit tests in place for this
+    module and that additional test cases were added to verify the fix.
+  code: true
+  fix: true
 discovered:
   question: |
     How was this vulnerability discovered?
@@ -95,11 +105,14 @@ discovered:
 
     If there is no evidence as to how this vulnerability was found, then you may
     leave the entries blank except for "answer". Write down where you looked in "answer".
-  answer: 
-  date: 
-  automated: 
-  google: 
-  contest: 
+  answer: |
+    It is not clear how this vulnerability was discoverd, if by manual inspection
+    by fuzzer; however, it was reproduced manually using an exploit provided in
+    the issue report.
+  date: 2015-12-14
+  automated:
+  google: false
+  contest: false
 subsystem:
   question: |
     What subsystems was the mistake in?
@@ -107,8 +120,8 @@ subsystem:
     Look at the path of the source code files code that were fixed to get
     directory names. Look at comments in the code. Look at the bug reports how
     the bug report was tagged. Examples: "clipboard", "gpu", "ssl", "speech", "renderer"
-  answer: 
-  name: 
+  answer: Based on the issue report.
+  name: Internals>Plugins>Pepper
 interesting_commits:
   question: |
     Are there any interesting commits between your VCC(s) and fix(es)?
@@ -120,10 +133,23 @@ interesting_commits:
     If there are no interesting commits, demonstrate that you completed this section by explaining what happened between the VCCs and the fix.
   answer:
   commits:
-  - commit: 
-    note: 
-  - commit: 
-    note: 
+  - commit: f7624d0002bfdc2d67f4d28b680426d0bbc1535d
+    note: |
+      The code eventually used to fix this vulnerability was introduced six years 
+      prior to the discovery of this vulnerability and two years after the vulnerable
+      code was introduced into the repository.
+
+      At this point it seems like the developers were aware of the possible problems
+      with arbitrary script execution within modal loops.
+  - commit: b5717a4f9f66283a9fe04ae1f9a3a89920d5b6b0
+    note: |
+      The task handler system that is used to run recursive message modal loop was 
+      updated to make nested message loops safer. However, the developers added warnings 
+      in the comments that in general nestable message loops should be avoided because
+      they are dangerous and difficult to get right.
+
+      In this commit, the vulnerable Flash Message Loop was updated to use the updated
+      task handler.
 major_events:
   question: |
     Please record any major events you found in the history of this
@@ -157,8 +183,9 @@ lessons:
     applies: 
     note: 
   least_privilege:
-    applies: 
-    note: 
+    applies: true 
+    note: |
+      The nested modals allowed were allowed to bypass the the Same Origin Policy.
   frameworks_are_optional:
     applies: 
     note: 
@@ -166,8 +193,10 @@ lessons:
     applies: 
     note: 
   distrust_input:
-    applies: 
-    note: 
+    applies: true
+    note: |
+      The vulnerability involves nested modals having cross-side scripting vulnerabilities.
+      The contents of the modal message should be treated as malicious.
   security_by_obscurity:
     applies: 
     note: 
@@ -184,8 +213,15 @@ lessons:
     applies: 
     note: 
   complex_inputs:
-    applies: 
-    note: 
+    applies:
+    note:
+  cognitive_complexity:
+    applies: true
+    note: |
+      The vulnerability involves the use of many different components inside of a 
+      recursive loop which may cause state changes. State has to be handeled carefully
+      in order to provide protections inside the nested loop and then restore functionality
+      once the loop has ended.
 mistakes:
   question: |
     In your opinion, after all of this research, what mistakes were made that
@@ -198,4 +234,18 @@ mistakes:
     Use those questions to inspire your answer. Don't feel obligated to answer
     every one. Write a thoughtful entry here that those ing the software
     engineering industry would find interesting.
-  answer: 
+  answer: |
+    The vulnerability was essentially a design mistake that gave nested modals
+    the privledge to bypass the Same Origin Policy. It is interesting that the
+    two methods used to mitigate this vulnerability were in the repository for 
+    six years before it was discovered.
+
+    It appears that trust boundaries were drawn, but not around all the components
+    that may cross it. Proper analysis of the architecture is really the only mitigation
+    against this kind of vulnerability. Since this vulnerability was found by someone
+    outside the chromium team, it is unclear if this has been done.
+    
+    The lesson to be learned here is that it is not good enough to discover a 
+    possible attack vector and fix it in place and just apply this knowledge to
+    future development. This knowledge needs to be applied to the existing code
+    base as well.

--- a/cves/CVE-2016-1631.yml
+++ b/cves/CVE-2016-1631.yml
@@ -61,10 +61,10 @@ fixes_vcc_instructions: |
   CVE-2011-3092.yml). Fixes and VCCs follow the same format.
 fixes:
 - :commit: dd77c2a41c72589d929db0592565125ca629fb2c
-  :note:
+  :note: Implemented suspension of callbacks and resource loading
 vccs:
 - :commit: cd2af395e8429a30bcee9e7ad7ec9f4b680c924d
-  :note:
+  :note: The file's introduction into the repository
 upvotes_instructions: |
   For the first round, ignore this upvotes number.
 
@@ -72,7 +72,7 @@ upvotes_instructions: |
   upvotes to each vulnerability you see. Your peers will tell you how
   interesting they think this vulnerability is, and you'll add that to the
   upvotes score on your branch.
-upvotes: 
+upvotes: 4
 unit_tested:
   question: |
     Were automated unit tests involved in this vulnerability?
@@ -238,14 +238,17 @@ mistakes:
     The vulnerability was essentially a design mistake that gave nested modals
     the privledge to bypass the Same Origin Policy. It is interesting that the
     two methods used to mitigate this vulnerability were in the repository for 
-    six years before it was discovered.
+    six years before it was discovered. 
+    
+    It's possible that there was a similar vulnerability that was found in the 
+    past. It's also possible that similar functionality was implemented in a different
+    system by a developer who may have had more knowledge or awareness of security.
 
     It appears that trust boundaries were drawn, but not around all of the components
     that may cross it. Proper analysis of the architecture is really the only mitigation
     against this kind of vulnerability. Since this vulnerability was found by someone
     outside the Chromium team, it is unclear if this has been done.
     
-    The lesson to be learned here is that it is not good enough to discover a 
-    possible attack vector and fix it in place and then apply this knowledge to
-    future development. This knowledge needs to be applied to the existing code
-    base as well.
+    The lesson to be learned here is that discovery of a vulnerability such as this warrents
+    an audit of existing subsystems that may also be susceptible the same vulnerability. This could 
+    be done with a fuzzer or by manual inspection of the code and design.


### PR DESCRIPTION
Updated information inside of CVEs 2010-0660 and 2016-1631.

CVE-2010-0660
Disclosure of sensitive data in the referrer header when redirecting from an HTTPS server to an HTTP server.

CVE-2016-1631
XSS in nested modal message loops that bypasses the Same Origin Policy. 

Note:
I was also assigned CVE-2016-1685, a miscalculation of a certain index which allows out-of-bounds reads in PDFium. The code for fixing this is located in a different repository that is maintained specifically for the PDFium plugin. The "fix" in the chromium repository was only updating the DEPS file.